### PR TITLE
Fix room join user list broadcast

### DIFF
--- a/server.js
+++ b/server.js
@@ -247,7 +247,7 @@ io.on('connection', async (socket)=>{
     // broadcast join
     const txt=`${u.username} è entrato nella stanza`;
     io.to(room.id).emit('chat:system',{ text:txt, kind:'info', ts:Date.now() });
-    io.to(roomId).emit('room:user_list', await buildUserList(roomId));
+    io.to(room.id).emit('room:user_list', await buildUserList(room.id));
 
   });
 


### PR DESCRIPTION
## Summary
- Ensure room join broadcasts user list using `room.id`

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a7476ef9dc832582f059262d31ceca