### PR TITLE
Prevent duplicate room sessions per user

### DIFF
--- a/server.js
+++ b/server.js
@@ -235,6 +235,18 @@ io.on('connection', async (socket)=>{
     const ban = await db.get('SELECT * FROM room_bans WHERE room_id=? AND user_id=?',[room.id,u.id]);
     if(ban){ if(!ban.until_ts || ban.until_ts > Date.now()){ return socket.emit('error',{message:'Sei bannato da questa stanza'}); } else { await db.run('DELETE FROM room_bans WHERE room_id=? AND user_id=?',[room.id,u.id]); } }
 
+    const existing = presence.get(room.id);
+    if(existing){
+      for(const sid of Array.from(existing)){
+        const prev = sockets.get(sid);
+        if(prev && prev.userId===u.id){
+          existing.delete(sid);
+          const os = io.sockets.sockets.get(sid);
+          os?.disconnect(true);
+        }
+      }
+    }
+
     if(srec.roomId){ presence.get(srec.roomId)?.delete(socket.id); socket.leave(srec.roomId); }
     srec.roomId=room.id; srec.effectiveRole=userEffectiveRole(srec.globalRole, await getRoomRole(room.id,u.id));
     ensurePresence(room.id).add(socket.id); socket.join(room.id);
@@ -247,7 +259,7 @@ io.on('connection', async (socket)=>{
     // broadcast join
     const txt=`${u.username} è entrato nella stanza`;
     io.to(room.id).emit('chat:system',{ text:txt, kind:'info', ts:Date.now() });
-    io.to(roomId).emit('room:user_list', await buildUserList(roomId));
+    io.to(room.id).emit('room:user_list', await buildUserList(room.id));
 
   });
 
@@ -261,7 +273,7 @@ io.on('connection', async (socket)=>{
     // broadcast left
     const txt=`${u.username} è uscito dalla stanza`;
     io.to(room.id).emit('chat:system',{ text:txt, kind:'info', ts:Date.now() });
-    io.to(roomId).emit('room:user_list', await buildUserList(roomId));
+    io.to(room.id).emit('room:user_list', await buildUserList(room.id));
   });
   // OWNER CLAIM
   socket.on('room:owner_claim', async ({roomId,password})=>{


### PR DESCRIPTION
## Summary
- Avoid multiple simultaneous connections for the same user in a room
- Correct room user list broadcasts to target the proper room

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a74816db348325ba5d09196b1fc675