### PR TITLE
Enable HTTPS for chat server and document TLS setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,6 @@
 PORT=4000
+TLS_CERT_PATH=./certs/server.crt
+TLS_KEY_PATH=./certs/server.key
 JWT_SECRET=supersecret-change-me
 DB_FILE=./data/berrychat.db
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+# Berry Chat Server
+
+## HTTPS configuration
+
+This server now expects an HTTPS certificate and key. Generate a self‑signed pair for development:
+
+```bash
+mkdir -p certs
+openssl req -newkey rsa:2048 -nodes -keyout certs/server.key -x509 -days 365 -out certs/server.crt
+```
+
+Set the following environment variables so the server can load the certificate:
+
+```
+TLS_CERT_PATH=./certs/server.crt
+TLS_KEY_PATH=./certs/server.key
+```
+
+Clients should connect using `https://` (or `wss://` for WebSocket) URLs.
+

--- a/client/ownerPassword.js
+++ b/client/ownerPassword.js
@@ -1,7 +1,7 @@
 import { io } from 'socket.io-client';
 
 // Simple client example showing how to display room owner password
-const socket = io('http://localhost:4000');
+const socket = io('https://localhost:4000');
 
 socket.on('room:owner_password', ({ roomId, password }) => {
   console.log(`Owner password for room ${roomId}: ${password}`);

--- a/server.js
+++ b/server.js
@@ -1,6 +1,6 @@
 import 'dotenv/config';
 import express from 'express';
-import http from 'http';
+import https from 'https';
 import { Server } from 'socket.io';
 import cors from 'cors';
 import jwt from 'jsonwebtoken';
@@ -18,9 +18,17 @@ app.use(cors());
 app.use(express.json());
 app.use('/uploads', express.static('./uploads'));
 
-const server = http.createServer(app);
+const TLS_CERT_PATH = process.env.TLS_CERT_PATH;
+const TLS_KEY_PATH = process.env.TLS_KEY_PATH;
+if (!TLS_CERT_PATH || !TLS_KEY_PATH) {
+  throw new Error('TLS_CERT_PATH and TLS_KEY_PATH must be set');
+}
+const server = https.createServer({
+  cert: fs.readFileSync(TLS_CERT_PATH),
+  key: fs.readFileSync(TLS_KEY_PATH)
+}, app);
 const io = new Server(server, {
-  cors: { origin: ['http://localhost:5173','http://localhost:3000'], credentials: true },
+  cors: { origin: ['https://localhost:5173','https://localhost:3000'], credentials: true },
   pingInterval: 25000, pingTimeout: 20000, perMessageDeflate: false, maxHttpBufferSize: 1_000_000
 });
 
@@ -392,4 +400,4 @@ io.on('connection', async (socket)=>{
   });
 });
 
-server.listen(PORT, ()=> logger.info(`Berry Chat server running on http://localhost:${PORT}`));
+server.listen(PORT, ()=> logger.info(`Berry Chat server running on https://localhost:${PORT}`));


### PR DESCRIPTION
## Summary
- switch Express/Socket.IO server to HTTPS and load cert/key from `TLS_CERT_PATH` and `TLS_KEY_PATH`
- update example client to connect via `https://` and expose new env vars in `.env.example`
- add README section documenting certificate generation and required environment variables

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68a834f4e2648325bfa380fb4938ab81