### PR TITLE
Encrypt owner passwords

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# Berry Chat Server
+
+## Owner password encryption
+
+Room owner passwords are encrypted at rest using AES-256-GCM. The encryption
+key is derived from the `OWNER_PASS_KEY` environment variable. Make sure this
+value is kept secret and never checked into source control. It should be stored
+in a secure secret manager or an environment variable on the host.
+
+### Key rotation
+
+To rotate the encryption key:
+
+1. Set the new key in `OWNER_PASS_KEY` and keep the old value in
+   `OLD_OWNER_PASS_KEY` while running the migration.
+2. Execute `node scripts/init-db.js` to re-encrypt all stored passwords using
+   the new key.
+3. Remove `OLD_OWNER_PASS_KEY` once migration completes.
+
+If the database contains legacy plaintext passwords, running the migration
+script once with only `OWNER_PASS_KEY` set will encrypt them in place.
+

--- a/encryption.js
+++ b/encryption.js
@@ -1,0 +1,32 @@
+import crypto from 'crypto';
+
+// Derive a 32-byte key from the provided secret
+const baseSecret = process.env.OWNER_PASS_KEY || 'insecure-default-key';
+const DEFAULT_KEY = crypto.createHash('sha256').update(baseSecret).digest();
+
+function getKey(secret) {
+  return secret ? crypto.createHash('sha256').update(String(secret)).digest() : DEFAULT_KEY;
+}
+
+export function encrypt(plaintext, key = DEFAULT_KEY) {
+  const iv = crypto.randomBytes(12); // AES-256-GCM standard IV length
+  const cipher = crypto.createCipheriv('aes-256-gcm', key, iv);
+  const encrypted = Buffer.concat([cipher.update(String(plaintext), 'utf8'), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  // store as base64(iv|tag|ciphertext)
+  return Buffer.concat([iv, tag, encrypted]).toString('base64');
+}
+
+export function decrypt(ciphertext, key = DEFAULT_KEY) {
+  const data = Buffer.from(String(ciphertext), 'base64');
+  const iv = data.subarray(0, 12);
+  const tag = data.subarray(12, 28);
+  const text = data.subarray(28);
+  const decipher = crypto.createDecipheriv('aes-256-gcm', key, iv);
+  decipher.setAuthTag(tag);
+  const decrypted = Buffer.concat([decipher.update(text), decipher.final()]);
+  return decrypted.toString('utf8');
+}
+
+export { getKey };
+


### PR DESCRIPTION
## Summary
- encrypt room owner passwords with AES-256-GCM and env key
- decrypt owner password only when sending to client
- migrate existing owner_password entries and document key rotation

## Testing
- `npm test` *(fails: Missing script "test")*
- `node --check server.js`
- `node --check scripts/init-db.js`
- `node scripts/init-db.js` *(fails: Cannot find package 'argon2')*


------
https://chatgpt.com/codex/tasks/task_e_68a834f8e91483259aa8b9cd15f1f5a2