### PR TITLE
Handle Node watch mode path errors

### DIFF
--- a/server.js
+++ b/server.js
@@ -14,6 +14,15 @@ import multer from 'multer';
 import path from 'path';
 import { encrypt, decrypt } from './encryption.js';
 
+// Ignore spurious watch mode errors where filename is null
+process.on('uncaughtException', (err) => {
+  if (err?.code === 'ERR_INVALID_ARG_TYPE' && err.message?.includes('paths[1]')) {
+    logger.warn(`Ignoring watch mode error: ${err.message}`);
+    return;
+  }
+  throw err;
+});
+
 const app = express();
 app.use(cors());
 app.use(express.json());


### PR DESCRIPTION
## Summary
- avoid server crash when Node's watch mode emits null filename

## Testing
- `node --check server.js`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a8d24b81788325b8893b8e470c425e